### PR TITLE
 Blanking rootdir for testing purposes only

### DIFF
--- a/automatic/Cygwin/tools/chocolateyInstall.ps1
+++ b/automatic/Cygwin/tools/chocolateyInstall.ps1
@@ -27,8 +27,8 @@ $silentArgs = @(
     '--quiet-mode'
     "--site $($pp.Site)"
     '--packages default'
-    "--root '$cygwin_root'"
-    "--local-package-dir '$cygwin_root'"
+    "--root ""$cygwin_root"""
+    "--local-package-dir ""$cygwin_root"""
 
     if (!$pp.DesktopIcon) { '--no-desktop' } else {  Write-Host 'Desktop icon will be created' }
     if ($pp.NoStartMenu)  { '--no-startmenu';        Write-Host 'No start menu items will be created' }

--- a/automatic/Cygwin/tools/chocolateyInstall.ps1
+++ b/automatic/Cygwin/tools/chocolateyInstall.ps1
@@ -1,4 +1,4 @@
-﻿$ErrorActionPreference = 'Stop'
+$ErrorActionPreference = 'Stop'
 
 $toolsPath = Split-Path $MyInvocation.MyCommand.Definition
 $pp = Get-PackageParameters
@@ -53,4 +53,6 @@ Install-BinFile -Name "Cygwin" -Path "$cygwin_root\Cygwin.bat"
 Write-Host "Copying cygwin package manager (setup) to $cygwin_root"
 $setup_path = if ((Get-OSArchitectureWidth 32) -or $env:ChocolateyForceX86) { $packageArgs.file } else { $packageArgs.file64 }
 New-Item -ItemType Directory -Path $cygwin_root
-Move-Item $setup_path $cygwin_root\cygwinsetup.exe -Force -ErrorAction SilentlyContinue
+$ErrorActionPreference = 'SilentlyContinue'
+Move-Item $setup_path $cygwin_root\cygwinsetup.exe -Force
+$ErrorActionPreference = 'Stop'

--- a/automatic/Cygwin/tools/chocolateyInstall.ps1
+++ b/automatic/Cygwin/tools/chocolateyInstall.ps1
@@ -52,4 +52,4 @@ Install-BinFile -Name "Cygwin" -Path "$cygwin_root\Cygwin.bat"
 
 Write-Host "Copying cygwin package manager (setup) to $cygwin_root"
 $setup_path = if ((Get-OSArchitectureWidth 32) -or $env:ChocolateyForceX86) { $packageArgs.file } else { $packageArgs.file64 }
-Move-Item $setup_path $cygwin_root\cygwinsetup.exe -Force
+Copy-Item $setup_path $cygwin_root\cygwinsetup.exe -Force

--- a/automatic/Cygwin/tools/chocolateyInstall.ps1
+++ b/automatic/Cygwin/tools/chocolateyInstall.ps1
@@ -52,8 +52,4 @@ Install-BinFile -Name "Cygwin" -Path "$cygwin_root\Cygwin.bat"
 
 Write-Host "Copying cygwin package manager (setup) to $cygwin_root"
 $setup_path = if ((Get-OSArchitectureWidth 32) -or $env:ChocolateyForceX86) { $packageArgs.file } else { $packageArgs.file64 }
-if (Test-Path "$setup_path") {
-Move-Item "$setup_path" "$cygwin_root\cygwinsetup.exe" -Force
-} else {
-Write-Warning "$setup_path not found. May have been moved or deleted prior to this step"
-}
+# Move-Item "$setup_path" "$cygwin_root\cygwinsetup.exe" -Force

--- a/automatic/Cygwin/tools/chocolateyInstall.ps1
+++ b/automatic/Cygwin/tools/chocolateyInstall.ps1
@@ -46,10 +46,11 @@ $packageArgs = @{
   silentArgs     = $silentArgs
   validExitCodes = @(0)
 }
-Install-ChocolateyInstallPackage @packageArgs
-
-Install-BinFile -Name "Cygwin" -Path "$cygwin_root\Cygwin.bat"
 
 Write-Host "Copying cygwin package manager (setup) to $cygwin_root"
 $setup_path = if ((Get-OSArchitectureWidth 32) -or $env:ChocolateyForceX86) { $packageArgs.file } else { $packageArgs.file64 }
-# Move-Item "$setup_path" "$cygwin_root\cygwinsetup.exe" -Force
+Move-Item "$setup_path" "$cygwin_root\cygwinsetup.exe" -Force
+
+Install-ChocolateyInstallPackage @packageArgs
+
+Install-BinFile -Name "Cygwin" -Path "$cygwin_root\Cygwin.bat"

--- a/automatic/Cygwin/tools/chocolateyInstall.ps1
+++ b/automatic/Cygwin/tools/chocolateyInstall.ps1
@@ -53,4 +53,4 @@ Install-BinFile -Name "Cygwin" -Path "$cygwin_root\Cygwin.bat"
 Write-Host "Copying cygwin package manager (setup) to $cygwin_root"
 $setup_path = if ((Get-OSArchitectureWidth 32) -or $env:ChocolateyForceX86) { $packageArgs.file } else { $packageArgs.file64 }
 New-Item -ItemType Directory -Path $cygwin_root
-Move-Item $setup_path $cygwin_root\cygwinsetup.exe -Force
+Move-Item $setup_path $cygwin_root\cygwinsetup.exe -Force -ErrorAction SilentlyContinue

--- a/automatic/Cygwin/tools/chocolateyInstall.ps1
+++ b/automatic/Cygwin/tools/chocolateyInstall.ps1
@@ -27,8 +27,8 @@ $silentArgs = @(
     '--quiet-mode'
     "--site $($pp.Site)"
     '--packages default'
-    "--root $cygwin_root"
-    "--local-package-dir $cygwin_root"
+    "--root '$cygwin_root'"
+    "--local-package-dir '$cygwin_root'"
 
     if (!$pp.DesktopIcon) { '--no-desktop' } else {  Write-Host 'Desktop icon will be created' }
     if ($pp.NoStartMenu)  { '--no-startmenu';        Write-Host 'No start menu items will be created' }

--- a/automatic/Cygwin/tools/chocolateyInstall.ps1
+++ b/automatic/Cygwin/tools/chocolateyInstall.ps1
@@ -49,7 +49,7 @@ $packageArgs = @{
 
 Write-Host "Copying cygwin package manager (setup) to $cygwin_root"
 $setup_path = if ((Get-OSArchitectureWidth 32) -or $env:ChocolateyForceX86) { $packageArgs.file } else { $packageArgs.file64 }
-Copy-Item "$setup_path" "$cygwin_root\cygwinsetup.exe" -Force
+Copy-Item -Path "$setup_path" -Destination "$cygwin_root\cygwinsetup.exe" -Force
 
 Install-ChocolateyInstallPackage @packageArgs
 

--- a/automatic/Cygwin/tools/chocolateyInstall.ps1
+++ b/automatic/Cygwin/tools/chocolateyInstall.ps1
@@ -52,4 +52,8 @@ Install-BinFile -Name "Cygwin" -Path "$cygwin_root\Cygwin.bat"
 
 Write-Host "Copying cygwin package manager (setup) to $cygwin_root"
 $setup_path = if ((Get-OSArchitectureWidth 32) -or $env:ChocolateyForceX86) { $packageArgs.file } else { $packageArgs.file64 }
+if (Test-Path "$setup_path") {
 Move-Item "$setup_path" "$cygwin_root\cygwinsetup.exe" -Force
+} else {
+Write-Warning "$setup_path not found. May have been moved or deleted prior to this step"
+}

--- a/automatic/Cygwin/tools/chocolateyInstall.ps1
+++ b/automatic/Cygwin/tools/chocolateyInstall.ps1
@@ -1,4 +1,4 @@
-$ErrorActionPreference = 'Stop'
+$ErrorActionPreference = 'SilentlyContinue'
 
 $toolsPath = Split-Path $MyInvocation.MyCommand.Definition
 $pp = Get-PackageParameters
@@ -52,7 +52,4 @@ Install-BinFile -Name "Cygwin" -Path "$cygwin_root\Cygwin.bat"
 
 Write-Host "Copying cygwin package manager (setup) to $cygwin_root"
 $setup_path = if ((Get-OSArchitectureWidth 32) -or $env:ChocolateyForceX86) { $packageArgs.file } else { $packageArgs.file64 }
-New-Item -ItemType Directory -Path $cygwin_root
-$ErrorActionPreference = 'SilentlyContinue'
 Move-Item $setup_path $cygwin_root\cygwinsetup.exe -Force
-$ErrorActionPreference = 'Stop'

--- a/automatic/Cygwin/tools/chocolateyInstall.ps1
+++ b/automatic/Cygwin/tools/chocolateyInstall.ps1
@@ -49,6 +49,8 @@ $packageArgs = @{
 
 Write-Host "Copying cygwin package manager (setup) to $cygwin_root"
 $setup_path = if ((Get-OSArchitectureWidth 32) -or $env:ChocolateyForceX86) { $packageArgs.file } else { $packageArgs.file64 }
+Write-Host "setup_path -$setup_path-"
+sleep 20
 Copy-Item -Path "$setup_path" -Destination "$cygwin_root\cygwinsetup.exe" -Force
 
 Install-ChocolateyInstallPackage @packageArgs

--- a/automatic/Cygwin/tools/chocolateyInstall.ps1
+++ b/automatic/Cygwin/tools/chocolateyInstall.ps1
@@ -49,7 +49,7 @@ $packageArgs = @{
 
 Write-Host "Copying cygwin package manager (setup) to $cygwin_root"
 $setup_path = if ((Get-OSArchitectureWidth 32) -or $env:ChocolateyForceX86) { $packageArgs.file } else { $packageArgs.file64 }
-Move-Item "$setup_path" "$cygwin_root\cygwinsetup.exe" -Force
+Copy-Item "$setup_path" "$cygwin_root\cygwinsetup.exe" -Force
 
 Install-ChocolateyInstallPackage @packageArgs
 

--- a/automatic/Cygwin/tools/chocolateyInstall.ps1
+++ b/automatic/Cygwin/tools/chocolateyInstall.ps1
@@ -52,4 +52,4 @@ Install-BinFile -Name "Cygwin" -Path "$cygwin_root\Cygwin.bat"
 
 Write-Host "Copying cygwin package manager (setup) to $cygwin_root"
 $setup_path = if ((Get-OSArchitectureWidth 32) -or $env:ChocolateyForceX86) { $packageArgs.file } else { $packageArgs.file64 }
-Copy-Item $setup_path $cygwin_root\cygwinsetup.exe -Force
+Move-Item "$setup_path" "$cygwin_root\cygwinsetup.exe" -Force

--- a/automatic/Cygwin/tools/chocolateyInstall.ps1
+++ b/automatic/Cygwin/tools/chocolateyInstall.ps1
@@ -46,13 +46,11 @@ $packageArgs = @{
   silentArgs     = $silentArgs
   validExitCodes = @(0)
 }
-
-Write-Host "Copying cygwin package manager (setup) to $cygwin_root"
-$setup_path = if ((Get-OSArchitectureWidth 32) -or $env:ChocolateyForceX86) { $packageArgs.file } else { $packageArgs.file64 }
-Write-Host "setup_path -$setup_path-"
-sleep 20
-Copy-Item -Path "$setup_path" -Destination "$cygwin_root\cygwinsetup.exe" -Force
-
 Install-ChocolateyInstallPackage @packageArgs
 
 Install-BinFile -Name "Cygwin" -Path "$cygwin_root\Cygwin.bat"
+
+Write-Host "Copying cygwin package manager (setup) to $cygwin_root"
+$setup_path = if ((Get-OSArchitectureWidth 32) -or $env:ChocolateyForceX86) { $packageArgs.file } else { $packageArgs.file64 }
+New-Item -ItemType Directory -Path $cygwin_root
+Move-Item $setup_path $cygwin_root\cygwinsetup.exe -Force

--- a/rb_veyor.yml
+++ b/rb_veyor.yml
@@ -91,6 +91,19 @@ build_script:
     Remove-ItemProperty -Path "HKLM:\SOFTWARE\Cygwin\setup" -Name "rootdir"
     choco install chocolatey-core.extension -y
     choco install Cygwin --params="/InstallDir:C:\Program Files\Cgywin" -s="C:\projects\development\packages" -dvy
+    # Diagnostic Testing
+    if (Test-Path "C:\Program Files\Cgywin") {
+    Write-Host "The folder C:\Program Files\Cgywin exists"
+    } else {
+    Write-Warning "The folder C:\Program Files\Cgywin DOES NOT Exist"
+    }
+    if (test-path "C:\Program Files\Cgywin\cygwinsetup.exe") {
+    Write-Host "The File cygwinsetup.exe exists at C:\Program Files\Cgywin"
+    } else {
+    Write-Warning "The File cygwinsetup.exe DOES NOT exist at C:\Program Files\Cgywin"
+    }
+    sleep 30
+    
     #cd ../automatic/windows10-media-creation-tool
     #./update.ps1
     7z a Choco_logs.zip $Env:ChocolateyInstall\logs\chocolatey.log

--- a/rb_veyor.yml
+++ b/rb_veyor.yml
@@ -90,7 +90,7 @@ build_script:
     # Removing rootdir for testing purposes only
     Remove-ItemProperty -Path "HKLM:\SOFTWARE\Cygwin\setup" -Name "rootdir"
     choco install chocolatey-core.extension -y
-    choco install Cygwin --params="/InstallDir:C:Program Files\Cgywin" -dvy
+    choco install Cygwin --params="/InstallDir:C:\Program Files\Cgywin" -dvy
     #cd ../automatic/windows10-media-creation-tool
     #./update.ps1
     7z a Choco_logs.zip $Env:ChocolateyInstall\logs\chocolatey.log

--- a/rb_veyor.yml
+++ b/rb_veyor.yml
@@ -86,10 +86,14 @@ build_script:
         }
     }
 
-    ./update_all.ps1 ad* -chocochk $true
+    ./update_all.ps1 cyg* -chocochk $true
+    # Blanking rootdir for testing purposes only
+    Set-ItemProperty 'HKLM:\SOFTWARE\Cygwin\setup' -Name "rootdir" -Value ""
+    choco install chocolatey-core.extension -y
+    choco install Cygwin --params="/InstallDir:C:Program Files\Cgywin" -dvy -s="C:\projects\development\packages"
     #cd ../automatic/windows10-media-creation-tool
     #./update.ps1
-    #7z a au_temp.zip $Env:TEMP\chocolatey\au\*
+    7z a Choco_logs.zip $Env:ChocolateyInstall\logs\chocolatey.log
     7z a AU_Updates_temp.zip $Env:TEMP\AU_Updates\*
     7z a All_nupkg_files.zip -r C:\projects\development\packages\*.nupkg
 

--- a/rb_veyor.yml
+++ b/rb_veyor.yml
@@ -90,7 +90,7 @@ build_script:
     # Removing rootdir for testing purposes only
     Remove-ItemProperty -Path "HKLM:\SOFTWARE\Cygwin\setup" -Name "rootdir"
     choco install chocolatey-core.extension -y
-    choco install Cygwin --params="/InstallDir:C:Program Files\Cgywin" -dvy -s="C:\projects\development\packages"
+    choco install Cygwin --params="/InstallDir:C:Program Files\Cgywin" -dvy
     #cd ../automatic/windows10-media-creation-tool
     #./update.ps1
     7z a Choco_logs.zip $Env:ChocolateyInstall\logs\chocolatey.log

--- a/rb_veyor.yml
+++ b/rb_veyor.yml
@@ -90,7 +90,7 @@ build_script:
     # Removing rootdir for testing purposes only
     Remove-ItemProperty -Path "HKLM:\SOFTWARE\Cygwin\setup" -Name "rootdir"
     choco install chocolatey-core.extension -y
-    choco install Cygwin --params="/InstallDir:C:\Program Files\Cgywin" -dvy
+    choco install Cygwin --params="/InstallDir:C:\Program Files\Cgywin" -s="C:\projects\development\packages" -dvy
     #cd ../automatic/windows10-media-creation-tool
     #./update.ps1
     7z a Choco_logs.zip $Env:ChocolateyInstall\logs\chocolatey.log

--- a/rb_veyor.yml
+++ b/rb_veyor.yml
@@ -92,18 +92,24 @@ build_script:
     choco install chocolatey-core.extension -y
     choco install Cygwin --params="/InstallDir:C:\Program Files\Cgywin" -s="C:\projects\development\packages" -dvy
     # Diagnostic Testing
-    if (Test-Path "C:\Program Files\Cgywin") {
-    Write-Host "The folder C:\Program Files\Cgywin exists"
+    Write-Warning "Starting Diagnostic Tests"
+    $Package_Folder = "C:\Program Files\Cgywin"
+    if (Test-Path $Package_Folder) {
+    Write-Host "The folder $Package_Folder exists"
+    Write-Host "Getting all exe files from $Package_Folder"
+    $Cygwin_exe_Files = Get-ChildItem -Path $Package_Folder -Filter *.exe
+      foreach( $PSItem in $Cygwin_exe_Files) {
+        if (Test-Path $PSItem) {
+            Write-Host "File $PSItem Exists at C:\Program Files\Cgywin"
+        } else {
+            Write-Warning "File $PSItem DOES NOT Exist at C:\Program Files\Cgywin"
+        }
+      }
     } else {
-    Write-Warning "The folder C:\Program Files\Cgywin DOES NOT Exist"
+    Write-Warning "The folder $Package_Folder DOES NOT Exist"
     }
-    if (test-path "C:\Program Files\Cgywin\cygwinsetup.exe") {
-    Write-Host "The File cygwinsetup.exe exists at C:\Program Files\Cgywin"
-    } else {
-    Write-Warning "The File cygwinsetup.exe DOES NOT exist at C:\Program Files\Cgywin"
-    }
-    sleep 30
-    
+    Write-Warning "Finis Diagnostic Tests and sleep for 20"
+    sleep 20    
     #cd ../automatic/windows10-media-creation-tool
     #./update.ps1
     7z a Choco_logs.zip $Env:ChocolateyInstall\logs\chocolatey.log

--- a/rb_veyor.yml
+++ b/rb_veyor.yml
@@ -87,8 +87,8 @@ build_script:
     }
 
     ./update_all.ps1 cyg* -chocochk $true
-    # Blanking rootdir for testing purposes only
-    Set-ItemProperty 'HKLM:\SOFTWARE\Cygwin\setup' -Name "rootdir" -Value ""
+    # Removing rootdir for testing purposes only
+    Remove-ItemProperty -Path "HKLM:\SOFTWARE\Cygwin\setup" -Name "rootdir"
     choco install chocolatey-core.extension -y
     choco install Cygwin --params="/InstallDir:C:Program Files\Cgywin" -dvy -s="C:\projects\development\packages"
     #cd ../automatic/windows10-media-creation-tool

--- a/rb_veyor.yml
+++ b/rb_veyor.yml
@@ -96,13 +96,14 @@ build_script:
     $Package_Folder = "C:\Program Files\Cgywin"
     if (Test-Path $Package_Folder) {
     Write-Host "The folder $Package_Folder exists"
-    Write-Host "Getting all exe files from $Package_Folder"
-    $Cygwin_exe_Files = Get-ChildItem -Path $Package_Folder -Filter *.exe
+    $Cygwin_exe_Files = Get-ChildItem -Path $Package_Folder
+    $count = $Cygwin_exe_Files.count
+    Write-Host "Getting all -$count- files from $Package_Folder"
       foreach( $PSItem in $Cygwin_exe_Files) {
-        if (Test-Path $PSItem) {
-            Write-Host "File $PSItem Exists at C:\Program Files\Cgywin"
+        if (Test-Path "$Package_Folder\$PSItem") {
+            Write-Host "File $PSItem Exists at $Package_Folder"
         } else {
-            Write-Warning "File $PSItem DOES NOT Exist at C:\Program Files\Cgywin"
+            Write-Warning "File $PSItem DOES NOT Exist at $Package_Folder"
         }
       }
     } else {


### PR DESCRIPTION
    # Blanking rootdir for testing purposes only
    Set-ItemProperty 'HKLM:\SOFTWARE\Cygwin\setup' -Name "rootdir" -Value ""
    choco install chocolatey-core.extension -y
    choco install Cygwin --params="/InstallDir:C:Program Files\Cgywin" -dvy -s="C:\projects\development\packages"

also chocolatey log zip file